### PR TITLE
Add config option to disable native pulse scheduling

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -112,6 +112,12 @@ const SECTIONS = [
         key: "run-query-within-transaction",
         display_name: t`Run query within transaction`,
         type: "boolean"
+      },
+      {
+        key: "disable-native-pulse-scheduling",
+        display_name: t`Disable Native Foundry Pulse Scheduling`,
+        description: t`Disable the built-in Foundry pulse scheduling system. Enable this when using an external Foundry Pulse Monitor Agent to prevent duplicate pulse deliveries.`,
+        type: "boolean"
       }
     ],
   },

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -17,7 +17,7 @@
              [interface :as mi]
              [pulse :as pulse :refer [Pulse]]
              [pulse-card-file :refer [PulseCardFile]]
-             [pulse-channel :refer [channel-types PulseChannel]]]
+             [pulse-channel :refer [channel-types]]]
             [metabase.pulse.render :as render]
             [metabase.util
              [i18n :refer [tru]]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -211,98 +211,24 @@
   (p/send-pulse! body)
   {:ok true})
 
-(defn- safe-parse-int
-  "Safely parse a value to integer, returning default if parsing fails"
-  [val default]
-  (try
-    (cond
-      (integer? val) val
-      (string? val) (Integer/parseInt val)
-      (keyword? val) (Integer/parseInt (name val))
-      :else default)
-    (catch Exception e
-      (log/warn "Failed to parse integer:" val e)
-      default)))
-
-(defn- matches-pulse-schedule?
-  "Check if execution time matches pulse schedule.
-   Focuses on date, hour, and minute - ignoring seconds and milliseconds."
-  [execution-time channel]
-  (when execution-time
-    (try
-      (let [exec-time (if (instance? java.sql.Timestamp execution-time)
-                        (.toLocalDateTime execution-time)
-                        execution-time)
-            exec-hour (.getHour exec-time)
-            exec-minute (.getMinute exec-time)
-            exec-day-of-week (-> (.getDayOfWeek exec-time)
-                     str
-                     clojure.string/lower-case
-                     (subs 0 3))
-
-            exec-day-of-month (.getDayOfMonth exec-time)
-            {:keys [schedule_type schedule_hour schedule_day schedule_frame]} channel
-            safe-schedule-hour (safe-parse-int schedule_hour 0)
-            safe-schedule-frame (safe-parse-int schedule_frame 1)
-            schedule-type-keyword (keyword schedule_type)]
-        (and
-         (= exec-minute 0) ;; Enforce top-of-hour execution
-         (case schedule-type-keyword
-           :hourly
-           (if (nil? schedule_hour)
-             true 
-             (= (mod exec-hour safe-schedule-hour) 0))
-
-           :daily
-           (= exec-hour safe-schedule-hour)
-
-           :weekly
-           (and (= exec-hour safe-schedule-hour)
-                (= exec-day-of-week schedule_day))
-
-           :monthly
-           (and (= exec-hour safe-schedule-hour)
-                (= exec-day-of-month safe-schedule-frame))
-
-           false)))
-      (catch Exception e
-        (log/warn "Error matching pulse schedule:" e)
-        false))))
-
-
-(defn- get-pulse-last-scheduled-execution
-  "Get the last scheduled execution time for a pulse by querying pulse_card_file table.
-   Only returns executions that match the pulse's actual schedule (ignoring manual sends).
-   Assumes a single enabled email channel per pulse."
+(defn- get-pulse-last-execution
+  "Get the last execution time for a pulse by querying pulse_card_file table.
+   Returns the most recent execution regardless of whether it was scheduled or manual."
   [pulse-id]
-  (let [;; Fetch the enabled email channel for this pulse
-        email-channel (db/select-one PulseChannel
-                         :pulse_id pulse-id
-                         :enabled true
-                         :channel_type "email")
-
-        ;; Get all executions in reverse-chronological order
-        executions (db/select [PulseCardFile :created_at]
-                              :pulse_id pulse-id
-                              {:order-by [[:created_at :desc]]})
-
-        ;; Find first execution that matches the schedule
-        last-scheduled-execution (when email-channel
-                                   (some #(when (matches-pulse-schedule? (:created_at %) email-channel) %)
-                                         executions))]
+  (let [;; Get the most recent execution
+        last-execution (db/select-one [PulseCardFile :created_at]
+                                      :pulse_id pulse-id
+                                      {:order-by [[:created_at :desc]]})]
     
     {:pulse_id pulse-id
-     :last_scheduled_execution (:created_at last-scheduled-execution)
-     :schedule_info (if email-channel
-                      [(select-keys email-channel [:schedule_type :schedule_hour :schedule_day :schedule_frame])]
-                      [])}))
+     :last_execution (:created_at last-execution)}))
 
 
 (api/defendpoint GET "/:id/last-execution"
-  "Get last scheduled execution info for a pulse based on pulse_card_file entries."
+  "Get last execution info for a pulse based on pulse_card_file entries."
   [id]
   (api/check-pulse-permission)
   (api/read-check Pulse id)
-  (get-pulse-last-scheduled-execution id))
+  (get-pulse-last-execution id))
 
 (api/define-routes)

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -275,24 +275,23 @@
    Only returns executions that match the pulse's actual schedule (ignoring manual sends).
    Assumes a single enabled email channel per pulse."
   [pulse-id]
-  (let [pulse-id-int pulse-id
-
-        ;; Fetch the enabled email channel for this pulse
+  (let [;; Fetch the enabled email channel for this pulse
         email-channel (db/select-one PulseChannel
-                         {:pulse_id pulse-id-int
-                          :enabled true
-                          :channel_type "email"})
+                         :pulse_id pulse-id
+                         :enabled true
+                         :channel_type "email")
 
         ;; Get all executions in reverse-chronological order
         executions (db/select [PulseCardFile :created_at]
-                              {:pulse_id pulse-id-int}
+                              :pulse_id pulse-id
                               {:order-by [[:created_at :desc]]})
 
         ;; Find first execution that matches the schedule
         last-scheduled-execution (when email-channel
                                    (some #(when (matches-pulse-schedule? (:created_at %) email-channel) %)
                                          executions))]
-    {:pulse_id pulse-id-int
+    
+    {:pulse_id pulse-id
      :last_scheduled_execution (:created_at last-scheduled-execution)
      :schedule_info (if email-channel
                       [(select-keys email-channel [:schedule_type :schedule_hour :schedule_day :schedule_frame])]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -301,6 +301,7 @@
 (api/defendpoint GET "/:id/last-execution"
   "Get last scheduled execution info for a pulse based on pulse_card_file entries."
   [id]
+  (api/check-pulse-permission)
   (api/read-check Pulse id)
   (get-pulse-last-scheduled-execution id))
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -297,6 +297,11 @@
   :type :boolean
   :default false)
 
+(defsetting disable-native-pulse-scheduling
+  (tru "Disable the built-in Foundry pulse scheduling system. Enable this when using an external Foundry Pulse Monitor Agent to prevent duplicate pulse deliveries.")
+  :type    :boolean
+  :default false)
+
 (defn remove-public-uuid-if-public-sharing-is-disabled
   "If public sharing is *disabled* and OBJECT has a `:public_uuid`, remove it so people don't try to use it (since it
    won't work). Intended for use as part of a `post-select` implementation for Cards and Dashboards."
@@ -367,4 +372,5 @@
    :ids_auth_client_id (setting/get :ids-auth-client-id)
    :ids_auth_authorize_api (setting/get :ids-auth-authorize-api)
    :ids_auth_client_redirect_url (setting/get :ids-auth-client-redirect-url)
-   :session_timeout_period (setting/get :session-timeout-period)})
+   :session_timeout_period (setting/get :session-timeout-period)
+   :disable_native_pulse_scheduling (disable-native-pulse-scheduling)})

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -225,9 +225,11 @@
     ;; do a try-catch around each notification so if one fails, we'll still send the other ones for example, an Alert
     ;; set up to send over both Slack & email: if Slack fails, we still want to send the email (#7409)
     (try
-      (send-notification! notification)
+      (when notification
+        (log/debug (trs "Sending notification: {0}" (pr-str (select-keys notification [:subject :recipients :message-type]))))
+        (send-notification! notification))
       (catch Throwable e
-        (log/error e (trs "Error sending notification!"))))))
+        (log/error e (trs "Error sending notification! Notification data: {0}" (pr-str notification)))))))
 
 (defn- pulse->notifications [{:keys [cards channel-ids], :as pulse}]
   (let [results     (for [card  cards
@@ -361,12 +363,13 @@
 (defn- create-email-notification
   [{:keys [id name] :as pulse} results {:keys [recipients] :as channel}]
   (log/debug (format "Sending Pulse (%d: %s) via Channel :email" id name))
-  (let [email-subject (str "Report: " name)
-        email-recipients (filterv u/email? (map :email recipients))]
-    {:subject email-subject
-     :recipients email-recipients
-     :message-type :html
-     :message (messages/render-report-email pulse results)}))
+  (let [email-subject (str "Report: " (or name "Unnamed Pulse"))
+        email-recipients (filterv u/email? (map :email (or recipients [])))]
+    (when (seq email-recipients)
+      {:subject email-subject
+       :recipients email-recipients
+       :message-type :html
+       :message (messages/render-report-email pulse results)})))
 
 (defn- pulse->email-notifications
   [{:keys [cards channel-ids] :as pulse}]
@@ -377,10 +380,13 @@
         channel-ids (or channel-ids (mapv :id (:channels pulse)))]
     (when (> (count results) 0)
       (for [channel-id channel-ids
-            :let [channel (some #(when (= channel-id (:id %)) %) (:channels pulse))]]
+            :let [channel (some #(when (= channel-id (:id %)) %) (:channels pulse))]
+            :when channel] ; Ensure channel exists
         (create-email-notification pulse results channel)))))
 
 (defn send-pulse!
   [{:keys [cards] :as pulse} & {:keys [channel-ids]}]
   {:pre [(map? pulse) (every? map? cards) (every? :id cards)]}
-  (send-notifications! (pulse->email-notifications (merge pulse (when channel-ids {:channel-ids channel-ids})))))
+  (if (public-settings/disable-native-pulse-scheduling)
+    (log/info (trs "Native pulse scheduling is disabled. Skipping pulse execution for pulse {0}" (:id pulse)))
+    (send-notifications! (pulse->email-notifications (merge pulse (when channel-ids {:channel-ids channel-ids}))))))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -387,6 +387,4 @@
 (defn send-pulse!
   [{:keys [cards] :as pulse} & {:keys [channel-ids]}]
   {:pre [(map? pulse) (every? map? cards) (every? :id cards)]}
-  (if (public-settings/disable-native-pulse-scheduling)
-    (log/info (trs "Native pulse scheduling is disabled. Skipping pulse execution for pulse {0}" (:id pulse)))
-    (send-notifications! (pulse->email-notifications (merge pulse (when channel-ids {:channel-ids channel-ids}))))))
+  (send-notifications! (pulse->email-notifications (merge pulse (when channel-ids {:channel-ids channel-ids})))))


### PR DESCRIPTION
Adds configuration option to disable native pulse scheduling.
Adds `/pulse/:id/last-execution` endpoint to get a pulse's last execution time.

**Other Changes**
* Add additional logs and null checks